### PR TITLE
Stack backtraces are now retained per exception throw as well as per op ...

### DIFF
--- a/build/Jamfile.v2
+++ b/build/Jamfile.v2
@@ -24,7 +24,7 @@ project boost/afio
       <toolset>msvc:<define>UNICODE 
       <toolset>msvc:<define>_UNICODE
       <target-os>linux:<linkflags>"-lpthread -ldl"
-      <target-os>freebsd:<linkflags>"-lpthread"
+      <target-os>freebsd:<linkflags>"-lpthread -lexecinfo"
       <link>shared:<define>BOOST_AFIO_DYN_LINK=1
       <link>shared:<library>../../system/build//boost_system
       <link>shared:<library>../../filesystem/build//boost_filesystem

--- a/doc/release_notes.qbk
+++ b/doc/release_notes.qbk
@@ -213,6 +213,10 @@ protection disappear.
 
 * Added is_open() to async_io_handle. Made pseudo deleted file filtering optional in enumerate().
 
+* Stack backtraces are now retained per exception throw as well as per op schedule if BOOST_AFIO_OP_STACKBACKTRACEDEPTH
+is defined (defaults to yes if NDEBUG is not defined). Also added MSVC support, and exceptions returned by the future
+handle now provide stack backtraces.
+
 TODO BEFORE RELEASE
 
 1b. Add unit test swapping two directories

--- a/include/boost/afio/afio.hpp
+++ b/include/boost/afio/afio.hpp
@@ -797,6 +797,13 @@ namespace detail {
         "lock"
     };
     static_assert(static_cast<size_t>(OpType::Last)==sizeof(optypes)/sizeof(*optypes), "You forgot to fix up the strings matching OpType");
+
+    enum class unit_testing_flags : size_t
+    {
+        none=0,                  //!< No flags set
+        no_symbol_lookup=(1<<0)  //!< Don't bother looking up symbols in stack backtracing as it's horribly slow on POSIX especially
+    };
+    BOOST_AFIO_DECLARE_CLASS_ENUM_AS_BITFIELD(unit_testing_flags)
 }
 
 class async_io_handle;
@@ -1414,6 +1421,7 @@ protected:
         return std::make_pair(true, h);
     }
 public:
+    BOOST_AFIO_HEADERS_ONLY_MEMFUNC_SPEC void testing_flags(detail::unit_testing_flags flags);
     //! Destroys the dispatcher, blocking inefficiently if any ops are still in flight.
     BOOST_AFIO_HEADERS_ONLY_VIRTUAL_SPEC ~async_file_io_dispatcher_base();
 

--- a/include/boost/afio/config.hpp
+++ b/include/boost/afio/config.hpp
@@ -405,6 +405,8 @@ BOOST_AFIO_V1_NAMESPACE_END
 #  define BOOST_AFIO_THREAD_LOCAL thread_local
 # elif defined(_MSC_VER)
 #  define BOOST_AFIO_THREAD_LOCAL __declspec(thread)
+# elif defined(__GNUC__)
+#  define BOOST_AFIO_THREAD_LOCAL __thread
 # else
 #  error Unknown compiler, cannot set BOOST_AFIO_THREAD_LOCAL
 # endif

--- a/include/boost/afio/config.hpp
+++ b/include/boost/afio/config.hpp
@@ -400,5 +400,16 @@ BOOST_AFIO_V1_NAMESPACE_END
 # endif
 #endif
 
+#ifndef BOOST_AFIO_THREAD_LOCAL
+# ifdef __cpp_thread_local
+#  define BOOST_AFIO_THREAD_LOCAL thread_local
+# elif defined(_MSC_VER)
+#  define BOOST_AFIO_THREAD_LOCAL __declspec(thread)
+# else
+#  error Unknown compiler, cannot set BOOST_AFIO_THREAD_LOCAL
+# endif
+#endif
+
+
 #endif  // BOOST_AFIO_NEED_DEFINE
 

--- a/include/boost/afio/detail/Utility.hpp
+++ b/include/boost/afio/detail/Utility.hpp
@@ -210,9 +210,11 @@ BOOST_AFIO_V1_NAMESPACE_BEGIN
 #if BOOST_AFIO_USE_BOOST_THREAD
     typedef boost::exception_ptr exception_ptr;
     using boost::current_exception;
+    using boost::rethrow_exception;
 #else
     typedef std::exception_ptr exception_ptr;
     using std::current_exception;
+    using std::rethrow_exception;
 #endif
     // Get an exception ptr from a future
     template<typename T> inline exception_ptr get_exception_ptr(future<T> &f)

--- a/include/boost/afio/detail/impl/ErrorHandling.ipp
+++ b/include/boost/afio/detail/impl/ErrorHandling.ipp
@@ -16,12 +16,12 @@ namespace detail {
 #ifdef BOOST_AFIO_OP_STACKBACKTRACEDEPTH
     try
     {
-      if(!afio_exception_stack)
-        afio_exception_stack=new afio_exception_stack_t;
+      if(!afio_exception_stack())
+        afio_exception_stack()=new afio_exception_stack_t;
       afio_exception_stack_entry se;
       se.name=std::move(name);
       collect_stack(se.stack);
-      afio_exception_stack->push_back(std::move(se));
+      afio_exception_stack()->push_back(std::move(se));
     } catch(...) { }
 #endif
   }

--- a/include/boost/afio/detail/impl/ErrorHandling.ipp
+++ b/include/boost/afio/detail/impl/ErrorHandling.ipp
@@ -9,6 +9,25 @@ File Created: Nov 2012
 #include <locale>
 #include <cstring>
 
+BOOST_AFIO_V1_NAMESPACE_BEGIN
+namespace detail {
+  inline void push_exception(std::string name) BOOST_NOEXCEPT
+  {
+#ifdef BOOST_AFIO_OP_STACKBACKTRACEDEPTH
+    try
+    {
+      if(!afio_exception_stack)
+        afio_exception_stack=new afio_exception_stack_t;
+      afio_exception_stack_entry se;
+      se.name=std::move(name);
+      collect_stack(se.stack);
+      afio_exception_stack->push_back(std::move(se));
+    } catch(...) { }
+#endif
+  }
+}
+BOOST_AFIO_V1_NAMESPACE_END
+
 #ifdef WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN 1
@@ -62,6 +81,7 @@ BOOST_AFIO_V1_NAMESPACE_BEGIN
                     }
                 }
                 BOOST_AFIO_DEBUG_PRINT("! %s\n", errstr.c_str());
+                push_exception(errstr);
                 BOOST_AFIO_THROW(system_error(ec, errstr));
             }
 
@@ -128,6 +148,7 @@ BOOST_AFIO_V1_NAMESPACE_BEGIN
                     }
                 }
                 BOOST_AFIO_DEBUG_PRINT("! %s\n", errstr.c_str());
+                push_exception(errstr);
                 BOOST_AFIO_THROW(system_error(ec, errstr));
             }
 
@@ -165,6 +186,7 @@ BOOST_AFIO_V1_NAMESPACE_BEGIN
                     }
                 }
                 BOOST_AFIO_DEBUG_PRINT("! %s\n", errstr.c_str());
+                push_exception(errstr);
                 BOOST_AFIO_THROW(system_error(ec, errstr));
             }// end int_throwOSError
   }// namespace detail

--- a/include/boost/afio/detail/impl/afio.ipp
+++ b/include/boost/afio/detail/impl/afio.ipp
@@ -27,7 +27,7 @@ File Created: Mar 2013
 
 // Define this to have every allocated op take a backtrace from where it was allocated
 #ifndef BOOST_AFIO_OP_STACKBACKTRACEDEPTH
-  #ifndef NDEBUG
+  #if !defined(NDEBUG) || defined(BOOST_AFIO_RUNNING_IN_CI)
     #define BOOST_AFIO_OP_STACKBACKTRACEDEPTH 8
   #endif
 #endif
@@ -695,13 +695,10 @@ namespace detail {
     BOOST_AFIO_HEADERS_ONLY_MEMFUNC_SPEC void print_fatal_exception_message_to_stderr(const char *msg)
     {
         std::cerr << "FATAL EXCEPTION: " << msg << std::endl;
-#if !defined(BOOST_AFIO_COMPILING_FOR_GCOV) && defined(__linux__) && !defined(__ANDROID__)
-        void *array[20];
-        size_t size=backtrace(array, 20);
-        char **strings=backtrace_symbols(array, size);
-        for(size_t i=0; i<size; i++)
-            std::cerr << "   " << strings[i] << std::endl;
-        free(strings);
+#ifdef BOOST_AFIO_OP_STACKBACKTRACEDEPTH
+        stack_type stack;
+        collect_stack(stack);
+        print_stack(std::cerr, stack);
 #endif
     }
     

--- a/include/boost/afio/detail/impl/afio.ipp
+++ b/include/boost/afio/detail/impl/afio.ipp
@@ -1774,10 +1774,10 @@ BOOST_AFIO_HEADERS_ONLY_MEMFUNC_SPEC void async_file_io_dispatcher_base::complet
         if(afio_exception_stack())
         {
           std::string originalmsg;
-          std::error_code ec;
+          asio::error_code ec;
           bool is_runtime_error=false, is_system_error=false;
           try { rethrow_exception(e); }
-          catch(const std::system_error &r) { ec=r.code(); originalmsg=r.what(); is_system_error=true; }
+          catch(const system_error &r) { ec=r.code(); originalmsg=r.what(); is_system_error=true; }
           catch(const std::runtime_error &r) { originalmsg=r.what(); is_runtime_error=true; }
           catch(...) { }
           if(is_runtime_error || is_system_error)
@@ -1793,7 +1793,7 @@ BOOST_AFIO_HEADERS_ONLY_MEMFUNC_SPEC void async_file_io_dispatcher_base::complet
               print_stack(buffer, i.stack);
             }
             if(is_system_error)
-              e=make_exception_ptr(std::system_error(ec, buffer.str()));
+              e=make_exception_ptr(system_error(ec, buffer.str()));
             else
               e=make_exception_ptr(std::runtime_error(buffer.str()));
           }

--- a/standalone_alltests_gcc.sh
+++ b/standalone_alltests_gcc.sh
@@ -6,10 +6,14 @@ if [ -z "$CXX" ]; then
     CXX=g++
   fi
 fi
-if [ "$CXX" != "${CXX#clang++}" ] && [ "$NODE_NAME" = "linux-gcc-clang" ]; then
-  LIBATOMIC=-latomic
+HOSTOS=$(uname)
+if [ "$HOSTOS" = "Linux" ]; then
+  LIBATOMIC="-ldl"
+  if [ "$CXX" != "${CXX#clang++}" ] && [ "$NODE_NAME" = "linux-gcc-clang" ]; then
+    LIBATOMIC="$LIBATOMIC -latomic"
+  fi
 fi
-if [ "$HOSTTYPE" = "FreeBSD" ] || [ "$NODE_NAME" = "freebsd10-clang3.3" ]; then
+if [ "$HOSTOS" = "FreeBSD" ]; then
   LIBATOMIC="-I/usr/local/include -L/usr/local/lib"
 fi
 if [ ! -d asio ]; then
@@ -19,4 +23,4 @@ cd test
 sh ./test_file_glob.sh
 cd ..
 rm -rf test_all
-$CXX -o test_all -g -O3 -std=c++11 test/test_all.cpp detail/SpookyV2.cpp -Iinclude -Itest -DAFIO_STANDALONE=1 -Iasio/asio/include -DSPINLOCK_STANDALONE=1 -DASIO_STANDALONE=1  -DBOOST_AFIO_RUNNING_IN_CI=1 -Wno-constexpr-not-const -Wno-c++1y-extensions -Wno-unused-value -lboost_filesystem -lboost_system -lpthread $LIBATOMIC
+$CXX -o test_all -g -O3 -std=c++11 -rdynamic -fstrict-aliasing -Wstrict-aliasing -Wno-unused -fargument-noalias -fasynchronous-unwind-tables test/test_all.cpp detail/SpookyV2.cpp -Iinclude -Itest -DAFIO_STANDALONE=1 -Iasio/asio/include -DSPINLOCK_STANDALONE=1 -DASIO_STANDALONE=1  -DBOOST_AFIO_RUNNING_IN_CI=1 -Wno-constexpr-not-const -Wno-c++1y-extensions -Wno-unused-value -lboost_filesystem -lboost_system -lpthread $LIBATOMIC

--- a/standalone_alltests_gcc.sh
+++ b/standalone_alltests_gcc.sh
@@ -14,7 +14,7 @@ if [ "$HOSTOS" = "Linux" ]; then
   fi
 fi
 if [ "$HOSTOS" = "FreeBSD" ]; then
-  LIBATOMIC="-I/usr/local/include -L/usr/local/lib"
+  LIBATOMIC="-I/usr/local/include -L/usr/local/lib -lexecinfo"
 fi
 if [ ! -d asio ]; then
   sh -c "git clone https://github.com/chriskohlhoff/asio.git"

--- a/standalone_alltests_gcc.sh
+++ b/standalone_alltests_gcc.sh
@@ -23,4 +23,4 @@ cd test
 sh ./test_file_glob.sh
 cd ..
 rm -rf test_all
-$CXX -o test_all -g -O3 -std=c++11 -rdynamic -fstrict-aliasing -Wstrict-aliasing -Wno-unused -fargument-noalias -fasynchronous-unwind-tables test/test_all.cpp detail/SpookyV2.cpp -Iinclude -Itest -DAFIO_STANDALONE=1 -Iasio/asio/include -DSPINLOCK_STANDALONE=1 -DASIO_STANDALONE=1  -DBOOST_AFIO_RUNNING_IN_CI=1 -Wno-constexpr-not-const -Wno-c++1y-extensions -Wno-unused-value -lboost_filesystem -lboost_system -lpthread $LIBATOMIC
+$CXX -o test_all -g -O3 -std=c++11 -rdynamic -fstrict-aliasing -Wstrict-aliasing -Wno-unused -fasynchronous-unwind-tables test/test_all.cpp detail/SpookyV2.cpp -Iinclude -Itest -DAFIO_STANDALONE=1 -Iasio/asio/include -DSPINLOCK_STANDALONE=1 -DASIO_STANDALONE=1  -DBOOST_AFIO_RUNNING_IN_CI=1 -Wno-constexpr-not-const -Wno-c++1y-extensions -Wno-unused-value -lboost_filesystem -lboost_system -lpthread $LIBATOMIC

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -105,7 +105,7 @@ project boost/afio/test
       <toolset>msvc:<define>UNICODE
       <toolset>msvc:<define>_UNICODE
       <target-os>linux:<linkflags>"-lpthread -ldl -lrt"
-      <target-os>freebsd:<linkflags>"-lpthread"
+      <target-os>freebsd:<linkflags>"-lpthread -lexecinfo"
       <link>shared:<define>BOOST_AFIO_DYN_LINK=1
       <library>../../system/build//boost_system
       <library>../../filesystem/build//boost_filesystem

--- a/test/tests/api_error_check.cpp
+++ b/test/tests/api_error_check.cpp
@@ -4,7 +4,9 @@ BOOST_AFIO_AUTO_TEST_CASE(api_error_check, "Tests that every API returns errors 
 {
     using namespace BOOST_AFIO_V1_NAMESPACE;
     auto dispatcher = make_async_file_io_dispatcher();
-#define BOOST_AFIO_CHECK_SYSTEM_ERROR_CODE(call, errcode) try { BOOST_TEST_MESSAGE("Testing " #call); call; BOOST_FAIL("Exception not thrown by " #call); } catch(const system_error &e) { BOOST_CHECK(e.code().value()==errcode); } catch(...) { BOOST_FAIL("Exception thrown by " #call " was not a system_error"); }
+#define BOOST_AFIO_CHECK_SYSTEM_ERROR_CODE(call, errcode) try { BOOST_TEST_MESSAGE("Testing " #call); call; BOOST_FAIL("Exception not thrown by " #call); } \
+  catch(const system_error &e) { BOOST_CHECK(e.code().value()==errcode); std::cout << "\nsystem_error message was: " << e.what() << std::endl; } \
+  catch(...) { BOOST_FAIL("Exception thrown by " #call " was not a system_error"); }
 #ifdef WIN32
 # define BOOST_AFIO_FILE_NOT_FOUND_ERRCODE ERROR_FILE_NOT_FOUND
 # define BOOST_AFIO_BAD_FD ERROR_INVALID_HANDLE

--- a/test/tests/api_error_check.cpp
+++ b/test/tests/api_error_check.cpp
@@ -5,7 +5,7 @@ BOOST_AFIO_AUTO_TEST_CASE(api_error_check, "Tests that every API returns errors 
     using namespace BOOST_AFIO_V1_NAMESPACE;
     auto dispatcher = make_async_file_io_dispatcher();
 #define BOOST_AFIO_CHECK_SYSTEM_ERROR_CODE(call, errcode) try { BOOST_TEST_MESSAGE("Testing " #call); call; BOOST_FAIL("Exception not thrown by " #call); } \
-  catch(const system_error &e) { BOOST_CHECK(e.code().value()==errcode); std::cout << "\nsystem_error message was: " << e.what() << std::endl; } \
+  catch(const system_error &e) { BOOST_CHECK(e.code().value()==errcode); std::cout << "\nsystem_error message from " #call " was: " << e.what() << std::endl; } \
   catch(...) { BOOST_FAIL("Exception thrown by " #call " was not a system_error"); }
 #ifdef WIN32
 # define BOOST_AFIO_FILE_NOT_FOUND_ERRCODE ERROR_FILE_NOT_FOUND

--- a/test/tests/async_io_errors_test.cpp
+++ b/test/tests/async_io_errors_test.cpp
@@ -25,6 +25,7 @@ BOOST_AFIO_AUTO_TEST_CASE(async_io_errors, "Tests that the async i/o error handl
     {
         int hasErrorDirectly, hasErrorFromBarrier;
         auto dispatcher = make_async_file_io_dispatcher();
+        dispatcher->testing_flags(detail::unit_testing_flags::no_symbol_lookup);
         auto mkdir(dispatcher->dir(async_path_op_req("testdir", file_flags::Create)));
         std::vector<async_path_op_req> filereqs;
 


### PR DESCRIPTION
...schedule if BOOST_AFIO_OP_STACKBACKTRACEDEPTH

is defined (defaults to yes if NDEBUG is not defined). Also added MSVC support, and exceptions returned by the future
handle now provide stack backtraces.