### PR TITLE
Fixes for the filecopy_example.cpp file.

### DIFF
--- a/example/filecopy_example.cpp
+++ b/example/filecopy_example.cpp
@@ -60,8 +60,11 @@ namespace {
                 size_t thischunk=(size_t)(bytes-o);
                 if(thischunk>chunk_size) thischunk=chunk_size;
                 // Schedule a filling of buffer from offset o after last has completed
-                auto readchunk=dispatcher->read(make_async_data_op_req(last, buffer->data(),
-                    thischunk, o));
+                // Note the call to dispatcher->depends(). After the each loop, last
+                // refers to an io_op that uses the output file, but we need to read from
+                // the input file.
+                auto readchunk = dispatcher->read(make_async_data_op_req(
+                    dispatcher->depends(last, ihs[idx]), buffer->data(), thischunk, o));
                 // Schedule a writing of buffer to offset offset+o after readchunk is ready
                 // Note the call to dispatcher->depends(). The precondition for the next operation
                 // is readchunk, but we need ohresize passed to dispatcher->write() in order

--- a/example/filecopy_example.cpp
+++ b/example/filecopy_example.cpp
@@ -102,7 +102,7 @@ int main(int argc, const char *argv[])
         boost::afio::filesystem::path dest=argv[1];
         std::vector<boost::afio::filesystem::path> sources;
         std::cout << "Concatenating into " << dest << " the files ";
-        for(int n=2; n<argc; argc++)
+        for(int n=2; n<argc; ++n)
         {
             sources.push_back(argv[n]);
             std::cout << sources.back();


### PR DESCRIPTION
Fixes two fatal bugs in the example:

1. The command line parser looped on the wrong variable.
2. The asynchronous write call used the wrong precondition, causing it to try to write to the current input file.

This fixes issue #71.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/boostgsoc13/boost.afio/74)
<!-- Reviewable:end -->
